### PR TITLE
New test case: Missing Host header

### DIFF
--- a/spec/http1.1/RFC9112.go
+++ b/spec/http1.1/RFC9112.go
@@ -1,0 +1,16 @@
+package http11
+
+import "github.com/LeaYeh/h1spec/spec"
+
+// RFC9112 is the main function for the RFC9112 protocol.
+// It creates a new test group for the protocol and adds chapter-level test groups to it.
+// The purpose of RFC9112 is to define the syntax and semantics of HTTP/1.1 request-target.
+func RFC9112() *spec.TestGroup {
+	tg := NewTestGroup("RFC9112", "Protocol RFC9112")
+
+	// Add chapter-level test groups
+	// The implementation of these test groups will be provided in future files
+	tg.AddTestGroup(HTTP11RequestTarget())
+
+	return tg
+}

--- a/spec/http1.1/RFC9112_3_2_MissingHostHeader.go
+++ b/spec/http1.1/RFC9112_3_2_MissingHostHeader.go
@@ -1,0 +1,41 @@
+package http11
+
+import (
+    "github.com/LeaYeh/h1spec/config"
+    "github.com/LeaYeh/h1spec/spec"
+)
+
+// HTTP11MissingHostHeader implements tests for RFC9112 Section 3.2: "Request Target".
+func HTTP11MissingHostHeader() *spec.TestGroup {
+    tg := NewTestGroup("RFC9112.3.2", "Request Target")
+    
+    tg.AddTestCase(&spec.TestCase{
+        Strict:      true, // true or false, based on the Mode
+        Desc:        "A server MUST respond with a 400 (Bad Request) status code to any HTTP/1.1 request message that lacks a Host header field and to any request message that contains more than one Host header field line or a Host header field with an invalid field value.",
+        Requirement: "The server MUST respond with a 400 (Bad Request) status code to any HTTP/1.1 request message that lacks a Host header field and to any request message that contains more than one Host header field line or a Host header field with an invalid field value.",
+        Run: func(c *config.Config, conn *spec.Conn) error {
+            expected := []string{spec.StatusString(1.1, 400, "\r")}
+            request := "GET / HTTP/1.1\r\n" +
+                "Connection: close\r\n\r\n"
+
+            err := conn.Send([]byte(request))
+            if err != nil {
+                return err
+            }
+            actual, err := conn.ReadLine()
+            if err != nil {
+                return err
+            }
+
+            if !spec.FindInSlice(expected, actual) {
+                return &spec.TestError{
+                    Expected: expected,
+                    Actual:   actual,
+                }
+            }
+            return nil
+        },
+    })
+    
+    return tg
+}

--- a/spec/http1.1/RFC9112_3_request_target.go
+++ b/spec/http1.1/RFC9112_3_request_target.go
@@ -1,0 +1,11 @@
+package http11
+
+import "github.com/LeaYeh/h1spec/spec"
+
+// HTTP11RequestTarget implements tests for RFC9112 Section 3: "Request Target".
+func HTTP11RequestTarget() *spec.TestGroup {
+    tg := NewTestGroup("RFC9112.3", "Request Target")
+    // Add subchapter-level test groups
+    tg.AddTestGroup(HTTP11MissingHostHeader())
+    return tg
+}


### PR DESCRIPTION
This PR adds a new test case as requested in issue #3.

Test Case Details:
- RFC Document: RFC 9112
- RFC Section: Section 3.2
- Test Case Name: Missing Host header
- Mode: MUST
- Sample Request: GET / HTTP/1.1
Connection: close
- Expected Status Code: 400
- Expected Headers: _No response_
- Expected Body: _No response_

Compilation Status: ✅ Code compiles successfully