### PR TITLE
New test case: Multiple Content-Length values in a request

### DIFF
--- a/.github/workflows/request-test-case.yml
+++ b/.github/workflows/request-test-case.yml
@@ -121,15 +121,20 @@ jobs:
           - Test Case Name: ${{ fromJson(steps.extract.outputs.result || '{}')['test-case-name'] || 'Untitled' }}
           - Mode: ${{ fromJson(steps.extract.outputs.result || '{}')['mode'] || 'Unknown' }}
           - Sample Request:
+
             ```
             ${{ fromJson(steps.extract.outputs.result || '{}')['sample-request'] || 'Unknown' }}
             ```
+
           - Expected Status Code: ${{ fromJson(steps.extract.outputs.result || '{}')['expected-status-code'] || 'Unknown' }}
           - Expected Headers:
+
             ```
             ${{ fromJson(steps.extract.outputs.result || '{}')['expected-headers'] || 'Unknown' }}
             ```
+
           - Expected Body:
+
             ```
             ${{ fromJson(steps.extract.outputs.result || '{}')['expected-body'] || 'Unknown' }}
             ```

--- a/spec/http1.1/RFC7230.go
+++ b/spec/http1.1/RFC7230.go
@@ -2,10 +2,18 @@ package http11
 
 import "github.com/LeaYeh/h1spec/spec"
 
+// RFC7230 is the main function for the RFC7230 test group.
+// It includes all the chapter-level test groups for RFC7230.
 func RFC7230() *spec.TestGroup {
 	tg := NewTestGroup("RFC7230", "Protocol RFC7230")
 
+	// IMPORTANT: Preserve existing test groups
 	tg.AddTestGroup(HTTP11Architecture())
+
+	// Add chapter-level test group for Message Body
+	// This test group will test the rules for the message body as defined in RFC7230 Section 3.3.3
+	// Reference Implementation will be in the future files
+	tg.AddTestGroup(HTTP11MessageBody())
 
 	return tg
 }

--- a/spec/http1.1/RFC7230_3_3_3_MultipleContentLength.go
+++ b/spec/http1.1/RFC7230_3_3_3_MultipleContentLength.go
@@ -1,0 +1,43 @@
+package http11
+
+import (
+    "github.com/LeaYeh/h1spec/config"
+    "github.com/LeaYeh/h1spec/spec"
+)
+
+// HTTP11MultipleContentLength implements tests for RFC7230 Section 3.3.3: "Message Body Length".
+func HTTP11MultipleContentLength() *spec.TestGroup {
+    tg := NewTestGroup("RFC7230.3.3.3", "Message Body Length")
+    
+    tg.AddTestCase(&spec.TestCase{
+        Strict:      true, // true or false, based on the Mode
+        Desc:        "Multiple Content-Length values in a request",
+        Requirement: "If a message is received without Transfer-Encoding and with multiple Content-Length header fields having differing field-values, then the message framing is invalid and the recipient MUST treat it as an unrecoverable error.  If this is a request message, the server MUST respond with a 400 (Bad Request) status code and then close the connection.",
+        Run: func(c *config.Config, conn *spec.Conn) error {
+            expected := []string{spec.StatusString(1.1, 400, "\r")}
+            request := "POST /submit HTTP/1.1\r\n" +
+                "Host: www.hehe.com\r\n" +
+                "Content-Length: 2000\r\n" +
+                "Content-Length: 3\r\n\r\n"
+
+            err := conn.Send([]byte(request))
+            if err != nil {
+                return err
+            }
+            actual, err := conn.ReadLine()
+            if err != nil {
+                return err
+            }
+
+            if !spec.FindInSlice(expected, actual) {
+                return &spec.TestError{
+                    Expected: expected,
+                    Actual:   actual,
+                }
+            }
+            return nil
+        },
+    })
+    
+    return tg
+}

--- a/spec/http1.1/RFC7230_3_message_body.go
+++ b/spec/http1.1/RFC7230_3_message_body.go
@@ -1,0 +1,12 @@
+package http11
+
+import "github.com/LeaYeh/h1spec/spec"
+
+// HTTP11MessageBody implements tests for RFC7230 Section 3: "Message Body".
+func HTTP11MessageBody() *spec.TestGroup {
+    tg := NewTestGroup("RFC7230.3", "Message Body")
+    // Add subchapter-level test groups and DO NOT implement the HTTP11MultipleContentLength in this file
+    // Reference Implementation will be in the future files
+    tg.AddTestGroup(HTTP11MultipleContentLength())
+    return tg
+}


### PR DESCRIPTION
Resolves #4

----

This PR adds a new test case as requested in issue #4.

Test Case Details:
- RFC Document: RFC 7230
- RFC Section: Section 3.3.3
- Test Case Name: Multiple Content-Length values in a request
- Mode: MUST
- Sample Request:

  ```
  POST /submit HTTP/1.1
Host: www.hehe.com
Content-Length: 2000
Content-Length: 3
  ```

- Expected Status Code: 400
- Expected Headers:

  ```
  Connection: close
  ```

- Expected Body:

  ```
  _No response_
  ```

Compilation Status: ✅ Code compiles successfully