### PR TITLE
New test case: Chunk Size can only contain hexadecimal characters (0123456789ABCDEFabcdef)

### DIFF
--- a/spec/http1.1/RFC9112.go
+++ b/spec/http1.1/RFC9112.go
@@ -2,15 +2,17 @@ package http11
 
 import "github.com/LeaYeh/h1spec/spec"
 
-// RFC9112 is the main function for the RFC9112 protocol.
-// It creates a new test group for the protocol and adds chapter-level test groups to it.
-// The purpose of RFC9112 is to define the syntax and semantics of HTTP/1.1 request-target.
 func RFC9112() *spec.TestGroup {
 	tg := NewTestGroup("RFC9112", "Protocol RFC9112")
 
-	// Add chapter-level test groups
-	// The implementation of these test groups will be provided in future files
-	tg.AddTestGroup(HTTP11RequestTarget())
+	// IMPORTANT: Preserve existing test groups
+    tg.AddTestGroup(HTTP11RequestTarget())
+
+	// Add chapter-level test group
+	// RFC9112.7: Chunked Transfer Coding
+	// This test group is to verify the implementation of chunked transfer coding in HTTP/1.1
+	// Reference Implementation will be in the future files
+	tg.AddTestGroup(HTTP11ChunkedTransferCoding())
 
 	return tg
 }

--- a/spec/http1.1/RFC9112_7_1_ChunkSizeHexadecimal.go
+++ b/spec/http1.1/RFC9112_7_1_ChunkSizeHexadecimal.go
@@ -1,0 +1,51 @@
+package http11
+
+import (
+    "github.com/LeaYeh/h1spec/config"
+    "github.com/LeaYeh/h1spec/spec"
+)
+
+// HTTP11ChunkSizeHexadecimal implements tests for RFC9112 Section 7.1: "Chunked Transfer Coding".
+func HTTP11ChunkSizeHexadecimal() *spec.TestGroup {
+    tg := NewTestGroup("RFC9112.7.1", "Chunked Transfer Coding")
+    
+    tg.AddTestCase(&spec.TestCase{
+        Strict:      true, // true or false, based on the Mode
+        Desc:        "Chunk Size can only contain hexadecimal characters (0123456789ABCDEFabcdef)",
+        Requirement: "The chunk-size field is a string of characters, each character being a hexadecimal digit (case-insensitive).",
+        Run: func(c *config.Config, conn *spec.Conn) error {
+            expected := []string{spec.StatusString(1.1, 400, "\r")}
+            request := "POST / HTTP/1.1\r\n" +
+                "Host: www.example.com\r\n" +
+                "Transfer-Encoding: chunked\r\n\r\n" +
+                "A\r\n" +
+                "0123456789\r\n" +
+                "1\r\n" +
+                "a\r\n" +
+                "2\r\n" +
+                "Hi\r\n" +
+                "+a\r\n" +
+                "0123456789\r\n" +
+                "0\r\n\r\n"
+
+            err := conn.Send([]byte(request))
+            if err != nil {
+                return err
+            }
+            actual, err := conn.ReadLine()
+            if err != nil {
+                return err
+            }
+
+            if !spec.FindInSlice(expected, actual) {
+                return &spec.TestError{
+                    Expected: expected,
+                    Actual:   actual,
+                }
+            }
+            return nil
+        },
+    })
+    
+    return tg
+}

--- a/spec/http1.1/RFC9112_7_chunked_transfer_coding.go
+++ b/spec/http1.1/RFC9112_7_chunked_transfer_coding.go
@@ -1,0 +1,12 @@
+package http11
+
+import "github.com/LeaYeh/h1spec/spec"
+
+// HTTP11ChunkedTransferCoding implements tests for RFC9112 Section 7: "Chunked Transfer Coding".
+func HTTP11ChunkedTransferCoding() *spec.TestGroup {
+    tg := NewTestGroup("RFC9112.7", "Chunked Transfer Coding")
+    // Add subchapter-level test groups and DO NOT implement the HTTP11ChunkSizeHexadecimal in this file
+    // Reference Implementation will be in the future files
+    tg.AddTestGroup(HTTP11ChunkSizeHexadecimal())
+    return tg
+}


### PR DESCRIPTION
Resolves #15

----

This PR adds a new test case as requested in issue #15.

Test Case Details:
- RFC Document: RFC 9112 - HTTP/1.1
- RFC Section: Section 7.1. Chunked Transfer Coding
- Test Case Name: Chunk Size can only contain hexadecimal characters (0123456789ABCDEFabcdef)
- Mode: MUST
- Sample Request:
  POST / HTTP/1.1
Host: www.example.com
Transfer-Encoding: chunked

A
0123456789
1
a
2
Hi
+a
0123456789
0

- Expected Status Code: 400
- Expected Headers:
  _No response_

- Expected Body:
  _No response_


Compilation Status: ✅ Code compiles successfully